### PR TITLE
2.0 release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 vendor
 composer.lock
 phpunit.xml
+/.phpunit.result.cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ cache:
 
 php:
   - '7.2'
+  - '7.3'
+  - '7.4'
 
 before_script:
   - composer self-update

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,6 @@ cache:
     - $HOME/.composer/cache
 
 php:
-  - '7.0'
-  - '7.1'
   - '7.2'
 
 before_script:

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,12 @@ UID := $(shell id -u)
 GID := $(shell id -g)
 PWD := $(shell pwd)
 
+phpcbf:
+	docker run --rm --user="${UID}:${GID}" -v ${PWD}:/app -w /app php:7.2-cli php vendor/bin/phpcbf
+
+phpcs:
+	docker run --rm --user="${UID}:${GID}" -v ${PWD}:/app -w /app php:7.2-cli php vendor/bin/phpcs
+
 phpunit:
 	docker run --rm --user="${UID}:${GID}" -v ${PWD}:/app -w /app php:7.2-cli php vendor/bin/phpunit
 	docker run --rm --user="${UID}:${GID}" -v ${PWD}:/app -w /app php:7.3-cli php vendor/bin/phpunit

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,10 @@
+MAKEFLAGS += --silent
+
+UID := $(shell id -u)
+GID := $(shell id -g)
+PWD := $(shell pwd)
+
+phpunit:
+	docker run --rm --user="${UID}:${GID}" -v ${PWD}:/app -w /app php:7.2-cli php vendor/bin/phpunit
+	docker run --rm --user="${UID}:${GID}" -v ${PWD}:/app -w /app php:7.3-cli php vendor/bin/phpunit
+	docker run --rm --user="${UID}:${GID}" -v ${PWD}:/app -w /app php:7.4-cli php vendor/bin/phpunit

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         }
     },
     "require": {
-        "php": "^7.0"
+        "php": "^7.2"
     },
     "require-dev": {
         "myonlinestore/coding-standard": "^1.0",
@@ -26,7 +26,7 @@
         "vendor-dir": "vendor",
         "sort-packages": true,
         "platform": {
-            "php": "7.0.33"
+            "php": "7.2.0"
         }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "require-dev": {
         "myonlinestore/coding-standard": "^1.0",
         "phpmd/phpmd": "^2.7",
-        "phpunit/phpunit": "^6"
+        "phpunit/phpunit": "^8.5"
     },
     "config": {
         "vendor-dir": "vendor",

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -2,10 +2,14 @@
 <ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:noNamespaceSchemaLocation="vendor/squizlabs/php_codesniffer/phpcs.xsd"
 >
-    <file>./</file>
-
-    <arg value="sp"/>
+    <arg name="basepath" value="."/>
+    <arg name="extensions" value="php"/>
+    <arg name="parallel" value="80"/>
     <arg name="colors"/>
+    <arg value="sp"/>
+
+    <file>src</file>
+    <file>tests</file>
 
     <rule ref="vendor/myonlinestore/coding-standard/MyOnlineStore/ruleset.xml"/>
 </ruleset>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -7,16 +7,15 @@
          convertNoticesToExceptions="true"
          convertWarningsToExceptions="true"
          processIsolation="false"
-         stopOnFailure="false"
-         syntaxCheck="false">
+         stopOnFailure="false">
     <testsuites>
         <testsuite name="Collection test suite">
-            <directory>./tests/</directory>
+            <directory>tests</directory>
         </testsuite>
     </testsuites>
     <filter>
         <whitelist>
-            <directory>./src</directory>
+            <directory>src</directory>
         </whitelist>
     </filter>
 </phpunit>

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -3,9 +3,8 @@ declare(strict_types=1);
 
 namespace MyOnlineStore\Common\Collection;
 
+// phpcs:disable
 abstract class Collection extends \ArrayObject
 {
     use CollectionTrait;
-
-    // phpcs:disable
 }

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -6,4 +6,6 @@ namespace MyOnlineStore\Common\Collection;
 abstract class Collection extends \ArrayObject
 {
     use CollectionTrait;
+
+    // phpcs:disable
 }

--- a/src/CollectionTrait.php
+++ b/src/CollectionTrait.php
@@ -5,16 +5,6 @@ namespace MyOnlineStore\Common\Collection;
 
 trait CollectionTrait
 {
-    /**
-     * @return static
-     * @deprecated Use \MyOnlineStore\Common\Collection\ClearTrait
-     *
-     */
-    public function clear()
-    {
-        return new static();
-    }
-
     public function isEmpty(): bool
     {
         return 0 === \count($this);

--- a/src/TypedCollectionTrait.php
+++ b/src/TypedCollectionTrait.php
@@ -10,7 +10,7 @@ trait TypedCollectionTrait
      *
      * @throws \InvalidArgumentException
      */
-    public function assertAcceptedElement($element)
+    public function assertAcceptedElement($element): void
     {
         if (!$this->isAcceptedElement($element)) {
             throw new \InvalidArgumentException(
@@ -26,7 +26,7 @@ trait TypedCollectionTrait
      *
      * @throws \InvalidArgumentException
      */
-    public function assertArray(array $array)
+    public function assertArray(array $array): void
     {
         \array_walk($array, [$this, 'assertAcceptedElement']);
     }

--- a/src/TypedIndexedCollectionTrait.php
+++ b/src/TypedIndexedCollectionTrait.php
@@ -10,7 +10,7 @@ trait TypedIndexedCollectionTrait
     /**
      * @throws \InvalidArgumentException
      */
-    public function assertAcceptedIndex(string $index)
+    public function assertAcceptedIndex(string $index): void
     {
         if (!$this->isAcceptedIndex($index)) {
             throw new \InvalidArgumentException(
@@ -24,11 +24,11 @@ trait TypedIndexedCollectionTrait
      *
      * @throws \InvalidArgumentException
      */
-    public function assertArray(array $array)
+    public function assertArray(array $array): void
     {
         foreach ($array as $index => $element) {
             // Cast to string since PHP converted numeric strings to integers
-            $this->assertAcceptedIndex((string) $index);
+            $this->assertAcceptedIndex((string)$index);
             $this->assertAcceptedElement($element);
         }
     }

--- a/src/TypedIndexedCollectionTrait.php
+++ b/src/TypedIndexedCollectionTrait.php
@@ -28,7 +28,7 @@ trait TypedIndexedCollectionTrait
     {
         foreach ($array as $index => $element) {
             // Cast to string since PHP converted numeric strings to integers
-            $this->assertAcceptedIndex((string)$index);
+            $this->assertAcceptedIndex((string) $index);
             $this->assertAcceptedElement($element);
         }
     }

--- a/tests/ClearTraitTest.php
+++ b/tests/ClearTraitTest.php
@@ -10,10 +10,7 @@ final class ClearTraitTest extends TestCase
 {
     public function testClearReturnsNewInstance(): void
     {
-        $collection = new class(['foo']) extends \ArrayObject {
-            use ClearTrait;
-        };
-
+        $collection = $this->createCollection(['foo']);
         $clearedCollection = $collection->clear();
 
         self::assertNotSame($collection, $clearedCollection);
@@ -22,14 +19,23 @@ final class ClearTraitTest extends TestCase
 
     public function testClearRemovesItems(): void
     {
-        $collection = new class(['foo']) extends \ArrayObject {
-            use ClearTrait;
-        };
-
+        $collection = $this->createCollection(['foo']);
         $clearedCollection = $collection->clear();
         \assert($clearedCollection instanceof \ArrayObject);
 
         self::assertNotEmpty($collection->getArrayCopy());
         self::assertEmpty($clearedCollection->getArrayCopy());
+    }
+
+    /**
+     * @param string[] $elements
+     */
+    protected function createCollection(array $elements): \ArrayObject
+    {
+        // phpcs:disable
+        return new class($elements) extends \ArrayObject {
+            use ClearTrait;
+        };
+        // phpcs:enable
     }
 }

--- a/tests/ClearTraitTest.php
+++ b/tests/ClearTraitTest.php
@@ -8,7 +8,7 @@ use PHPUnit\Framework\TestCase;
 
 final class ClearTraitTest extends TestCase
 {
-    public function testClearReturnsNewInstance()
+    public function testClearReturnsNewInstance(): void
     {
         $collection = new class(['foo']) extends \ArrayObject {
             use ClearTrait;
@@ -20,7 +20,7 @@ final class ClearTraitTest extends TestCase
         self::assertInstanceOf(\get_class($collection), $clearedCollection);
     }
 
-    public function testClearRemovesItems()
+    public function testClearRemovesItems(): void
     {
         $collection = new class(['foo']) extends \ArrayObject {
             use ClearTrait;

--- a/tests/ClearTraitTest.php
+++ b/tests/ClearTraitTest.php
@@ -8,15 +8,6 @@ use PHPUnit\Framework\TestCase;
 
 final class ClearTraitTest extends TestCase
 {
-    public function testClearReturnsNewInstance(): void
-    {
-        $collection = $this->createCollection(['foo']);
-        $clearedCollection = $collection->clear();
-
-        self::assertNotSame($collection, $clearedCollection);
-        self::assertInstanceOf(\get_class($collection), $clearedCollection);
-    }
-
     public function testClearRemovesItems(): void
     {
         $collection = $this->createCollection(['foo']);
@@ -25,6 +16,15 @@ final class ClearTraitTest extends TestCase
 
         self::assertNotEmpty($collection->getArrayCopy());
         self::assertEmpty($clearedCollection->getArrayCopy());
+    }
+
+    public function testClearReturnsNewInstance(): void
+    {
+        $collection = $this->createCollection(['foo']);
+        $clearedCollection = $collection->clear();
+
+        self::assertNotSame($collection, $clearedCollection);
+        self::assertInstanceOf(\get_class($collection), $clearedCollection);
     }
 
     /**

--- a/tests/CollectionTraitTest.php
+++ b/tests/CollectionTraitTest.php
@@ -9,14 +9,6 @@ use PHPUnit\Framework\TestCase;
 
 final class CollectionTraitTest extends TestCase
 {
-    public function testClear()
-    {
-        $collection = $this->getMockForTrait(CollectionTrait::class);
-        $clearedCollection = $collection->clear();
-        self::assertNotSame($collection, $clearedCollection);
-        self::assertInstanceOf(\get_class($collection), $clearedCollection);
-    }
-
     public function testFirstHavingWillReturnCorrectElements()
     {
         $element1 = $this->getMockBuilder(\stdClass::class)

--- a/tests/CollectionTraitTest.php
+++ b/tests/CollectionTraitTest.php
@@ -12,10 +12,10 @@ final class CollectionTraitTest extends TestCase
     public function testFirstHavingWillReturnCorrectElements()
     {
         $element1 = $this->getMockBuilder(\stdClass::class)
-            ->setMethods(['isFoobar'])
+            ->addMethods(['isFoobar'])
             ->getMock();
         $element2 = $this->getMockBuilder(\stdClass::class)
-            ->setMethods(['isFoobar'])
+            ->addMethods(['isFoobar'])
             ->getMock();
         $element1->expects(self::once())
             ->method('isFoobar')
@@ -33,6 +33,7 @@ final class CollectionTraitTest extends TestCase
                 }
             }
         };
+
         self::assertSame(
             $element2,
             $extendedClass->firstHaving(
@@ -46,10 +47,10 @@ final class CollectionTraitTest extends TestCase
     public function testFirstHavingWillThrowExceptionIfNoMatchIsFound()
     {
         $element1 = $this->getMockBuilder(\stdClass::class)
-            ->setMethods(['isFoobar'])
+            ->addMethods(['isFoobar'])
             ->getMock();
         $element2 = $this->getMockBuilder(\stdClass::class)
-            ->setMethods(['isFoobar'])
+            ->addMethods(['isFoobar'])
             ->getMock();
         $element1->expects(self::once())
             ->method('isFoobar')
@@ -94,6 +95,7 @@ final class CollectionTraitTest extends TestCase
         {
             use CollectionTrait;
         };
+
         self::assertTrue($collection1->isEmpty());
         self::assertFalse($collection2->isEmpty());
         self::assertFalse($collection3->isEmpty());

--- a/tests/CollectionTraitTest.php
+++ b/tests/CollectionTraitTest.php
@@ -24,19 +24,12 @@ final class CollectionTraitTest extends TestCase
             ->method('isFoobar')
             ->willReturn(true);
 
-        $extendedClass = new class([$element1, $element2]) extends Collection {
-            public function firstHaving(callable $callback): \stdClass
-            {
-                {
-                    return parent::firstHaving($callback);
-                }
-            }
-        };
+        $collection = $this->createCollection([$element1, $element2]);
 
         self::assertSame(
             $element2,
-            $extendedClass->firstHaving(
-                static function (\stdClass $element): \stdClass {
+            $collection->firstHaving(
+                static function (\stdClass $element): bool {
                     return $element->isFoobar();
                 }
             )
@@ -58,21 +51,14 @@ final class CollectionTraitTest extends TestCase
             ->method('isFoobar')
             ->willReturn(false);
 
-        $extendedClass = new class([$element1, $element2]) extends Collection {
-            public function firstHaving(callable $callback): \stdClass
-            {
-                {
-                    return parent::firstHaving($callback);
-                }
-            }
-        };
+        $collection = $this->createCollection([$element1, $element2]);
 
         $this->expectException(\OutOfBoundsException::class);
 
         self::assertSame(
             $element2,
-            $extendedClass->firstHaving(
-                static function (\stdClass $element): \stdClass {
+            $collection->firstHaving(
+                static function (\stdClass $element): bool {
                     return $element->isFoobar();
                 }
             )
@@ -81,6 +67,7 @@ final class CollectionTraitTest extends TestCase
 
     public function testIsEmpty(): void
     {
+        // phpcs:disable
         $collection1 = new class extends \ArrayObject {
             use CollectionTrait;
         };
@@ -90,9 +77,27 @@ final class CollectionTraitTest extends TestCase
         $collection3 = new class([null]) extends \ArrayObject {
             use CollectionTrait;
         };
+        // phpcs:enable
 
         self::assertTrue($collection1->isEmpty());
         self::assertFalse($collection2->isEmpty());
         self::assertFalse($collection3->isEmpty());
+    }
+
+    /**
+     * @param \stdClass[] $elements
+     */
+    protected function createCollection(array $elements): Collection
+    {
+        // phpcs:disable
+        return new class($elements) extends Collection {
+            public function firstHaving(callable $callback): \stdClass
+            {
+                {
+                    return parent::firstHaving($callback);
+                }
+            }
+        };
+        // phpcs:enable
     }
 }

--- a/tests/CollectionTraitTest.php
+++ b/tests/CollectionTraitTest.php
@@ -9,7 +9,7 @@ use PHPUnit\Framework\TestCase;
 
 final class CollectionTraitTest extends TestCase
 {
-    public function testFirstHavingWillReturnCorrectElements()
+    public function testFirstHavingWillReturnCorrectElements(): void
     {
         $element1 = $this->getMockBuilder(\stdClass::class)
             ->addMethods(['isFoobar'])
@@ -24,9 +24,8 @@ final class CollectionTraitTest extends TestCase
             ->method('isFoobar')
             ->willReturn(true);
 
-        $extendedClass = new class([$element1, $element2]) extends Collection
-        {
-            public function firstHaving(callable $callback)
+        $extendedClass = new class([$element1, $element2]) extends Collection {
+            public function firstHaving(callable $callback): \stdClass
             {
                 {
                     return parent::firstHaving($callback);
@@ -37,14 +36,14 @@ final class CollectionTraitTest extends TestCase
         self::assertSame(
             $element2,
             $extendedClass->firstHaving(
-                static function (\stdClass $element) {
+                static function (\stdClass $element): \stdClass {
                     return $element->isFoobar();
                 }
             )
         );
     }
 
-    public function testFirstHavingWillThrowExceptionIfNoMatchIsFound()
+    public function testFirstHavingWillThrowExceptionIfNoMatchIsFound(): void
     {
         $element1 = $this->getMockBuilder(\stdClass::class)
             ->addMethods(['isFoobar'])
@@ -59,9 +58,8 @@ final class CollectionTraitTest extends TestCase
             ->method('isFoobar')
             ->willReturn(false);
 
-        $extendedClass = new class([$element1, $element2]) extends Collection
-        {
-            public function firstHaving(callable $callback)
+        $extendedClass = new class([$element1, $element2]) extends Collection {
+            public function firstHaving(callable $callback): \stdClass
             {
                 {
                     return parent::firstHaving($callback);
@@ -74,25 +72,22 @@ final class CollectionTraitTest extends TestCase
         self::assertSame(
             $element2,
             $extendedClass->firstHaving(
-                static function (\stdClass $element) {
+                static function (\stdClass $element): \stdClass {
                     return $element->isFoobar();
                 }
             )
         );
     }
 
-    public function testIsEmpty()
+    public function testIsEmpty(): void
     {
-        $collection1 = new class extends \ArrayObject
-        {
+        $collection1 = new class extends \ArrayObject {
             use CollectionTrait;
         };
-        $collection2 = new class(['foo']) extends \ArrayObject
-        {
+        $collection2 = new class(['foo']) extends \ArrayObject {
             use CollectionTrait;
         };
-        $collection3 = new class([null]) extends \ArrayObject
-        {
+        $collection3 = new class([null]) extends \ArrayObject {
             use CollectionTrait;
         };
 

--- a/tests/FilterTraitTest.php
+++ b/tests/FilterTraitTest.php
@@ -12,10 +12,10 @@ final class FilterTraitTest extends TestCase
     public function testFirstHavingWillThrowExceptionIfNoMatchIsFound()
     {
         $element1 = $this->getMockBuilder(\stdClass::class)
-            ->setMethods(['isFoobar'])
+            ->addMethods(['isFoobar'])
             ->getMock();
         $element2 = $this->getMockBuilder(\stdClass::class)
-            ->setMethods(['isFoobar'])
+            ->addMethods(['isFoobar'])
             ->getMock();
         $element1->expects(self::once())
             ->method('isFoobar')

--- a/tests/FilterTraitTest.php
+++ b/tests/FilterTraitTest.php
@@ -24,10 +24,10 @@ final class FilterTraitTest extends TestCase
             ->method('isFoobar')
             ->willReturn(true);
 
-        $extendedClass = new class([$element1, $element2]) extends Collection {
+        $collection = new class([$element1, $element2]) extends Collection {
             use FilterTrait;
 
-            public function filterOnlyFoobar()
+            public function filterOnlyFoobar(): self
             {
                 return $this->filter(
                     static function (\stdClass $stdClass): bool {
@@ -38,8 +38,8 @@ final class FilterTraitTest extends TestCase
         };
 
         self::assertEquals(
-            new $extendedClass([$element2]),
-            $extendedClass->filterOnlyFoobar()
+            new $collection([$element2]),
+            $collection->filterOnlyFoobar()
         );
     }
 }

--- a/tests/FilterTraitTest.php
+++ b/tests/FilterTraitTest.php
@@ -9,7 +9,7 @@ use PHPUnit\Framework\TestCase;
 
 final class FilterTraitTest extends TestCase
 {
-    public function testFirstHavingWillThrowExceptionIfNoMatchIsFound()
+    public function testFirstHavingWillThrowExceptionIfNoMatchIsFound(): void
     {
         $element1 = $this->getMockBuilder(\stdClass::class)
             ->addMethods(['isFoobar'])

--- a/tests/IntegersTest.php
+++ b/tests/IntegersTest.php
@@ -11,7 +11,7 @@ final class IntegersTest extends TestCase
     /**
      * @throws \InvalidArgumentException
      */
-    public function testFromArray()
+    public function testFromArray(): void
     {
         self::assertEquals(new Integers([1, 14, 15, 16]), Integers::fromArray([true, '14', 15, 0x10]));
     }
@@ -19,7 +19,7 @@ final class IntegersTest extends TestCase
     /**
      * @throws \InvalidArgumentException
      */
-    public function testIsAcceptedElement()
+    public function testIsAcceptedElement(): void
     {
         $collection = new Integers();
 

--- a/tests/StringsTest.php
+++ b/tests/StringsTest.php
@@ -8,13 +8,13 @@ use PHPUnit\Framework\TestCase;
 
 final class StringsTest extends TestCase
 {
-    public function testFromArray()
+    public function testFromArray(): void
     {
         /** @noinspection PhpUnhandledExceptionInspection */
         self::assertEquals(new Strings(['1', '2.3', '45']), Strings::fromArray([1, 2.3, '45']));
     }
 
-    public function testIsAcceptedElement()
+    public function testIsAcceptedElement(): void
     {
         $collection = new Strings();
 
@@ -22,7 +22,7 @@ final class StringsTest extends TestCase
         self::assertFalse($collection->isAcceptedElement(new \stdClass()));
     }
 
-    public function testJoin()
+    public function testJoin(): void
     {
         /** @noinspection PhpUnhandledExceptionInspection */
         self::assertSame('foo_bar_baz', (new Strings(['foo', 'bar', 'baz']))->join('_'));

--- a/tests/TypedCollectionTest.php
+++ b/tests/TypedCollectionTest.php
@@ -10,12 +10,14 @@ final class TypedCollectionTest extends TestCase
 {
     public function testConstructWillAssertElements(): void
     {
+        // phpcs:disable
         $collection = new class extends TypedCollection {
             public function isAcceptedElement($element): bool
             {
                 return true;
             }
         };
+        // phpcs:enable
 
         self::assertInstanceOf(
             TypedCollection::class,

--- a/tests/TypedCollectionTest.php
+++ b/tests/TypedCollectionTest.php
@@ -8,16 +8,18 @@ use PHPUnit\Framework\TestCase;
 
 final class TypedCollectionTest extends TestCase
 {
-    public function testConstructWillAssertElements()
+    public function testConstructWillAssertElements(): void
     {
-        $collection = new class extends TypedCollection
-        {
+        $collection = new class extends TypedCollection {
             public function isAcceptedElement($element): bool
             {
                 return true;
             }
         };
 
-        self::assertInstanceOf(TypedCollection::class, new $collection([$this->createMock(\stdClass::class)]));
+        self::assertInstanceOf(
+            TypedCollection::class,
+            new $collection([$this->createMock(\stdClass::class)])
+        );
     }
 }

--- a/tests/TypedCollectionTraitTest.php
+++ b/tests/TypedCollectionTraitTest.php
@@ -8,7 +8,7 @@ use PHPUnit\Framework\TestCase;
 
 final class TypedCollectionTraitTest extends TestCase
 {
-    public function testAssertArray()
+    public function testAssertArray(): void
     {
         $element = new \stdClass();
 
@@ -24,7 +24,7 @@ final class TypedCollectionTraitTest extends TestCase
         $typedCollection->assertArray([$element]);
     }
 
-    public function testAssertAcceptedElementWillThrowExceptionOnUnacceptedElement()
+    public function testAssertAcceptedElementWillThrowExceptionOnUnacceptedElement(): void
     {
         $element = new \stdClass();
 
@@ -43,7 +43,7 @@ final class TypedCollectionTraitTest extends TestCase
         $typedCollection->assertAcceptedElement($element);
     }
 
-    public function testAssertAcceptedElementWillDoNothingOnAcceptedElement()
+    public function testAssertAcceptedElementWillDoNothingOnAcceptedElement(): void
     {
         $element = new \stdClass();
 

--- a/tests/TypedCollectionTraitTest.php
+++ b/tests/TypedCollectionTraitTest.php
@@ -13,7 +13,7 @@ final class TypedCollectionTraitTest extends TestCase
         $element = new \stdClass();
 
         $typedCollection = $this->getMockBuilder(TypedCollectionTrait::class)
-            ->setMethods(['assertAcceptedElement'])
+            ->onlyMethods(['assertAcceptedElement'])
             ->getMockForTrait();
 
         $typedCollection->expects(self::once())
@@ -29,7 +29,7 @@ final class TypedCollectionTraitTest extends TestCase
         $element = new \stdClass();
 
         $typedCollection = $this->getMockBuilder(TypedCollectionTrait::class)
-            ->setMethods(['isAcceptedElement'])
+            ->onlyMethods(['isAcceptedElement'])
             ->getMockForTrait();
 
         $typedCollection->expects(self::once())
@@ -48,7 +48,7 @@ final class TypedCollectionTraitTest extends TestCase
         $element = new \stdClass();
 
         $typedCollection = $this->getMockBuilder(TypedCollectionTrait::class)
-            ->setMethods(['isAcceptedElement'])
+            ->onlyMethods(['isAcceptedElement'])
             ->getMockForTrait();
 
         $typedCollection->expects(self::once())

--- a/tests/TypedCollectionTraitTest.php
+++ b/tests/TypedCollectionTraitTest.php
@@ -8,20 +8,21 @@ use PHPUnit\Framework\TestCase;
 
 final class TypedCollectionTraitTest extends TestCase
 {
-    public function testAssertArray(): void
+    public function testAssertAcceptedElementWillDoNothingOnAcceptedElement(): void
     {
         $element = new \stdClass();
 
         $typedCollection = $this->getMockBuilder(TypedCollectionTrait::class)
-            ->onlyMethods(['assertAcceptedElement'])
+            ->onlyMethods(['isAcceptedElement'])
             ->getMockForTrait();
 
         $typedCollection->expects(self::once())
-            ->method('assertAcceptedElement')
-            ->with($element);
+            ->method('isAcceptedElement')
+            ->with($element)
+            ->willReturn(true);
 
         /** @noinspection PhpUndefinedMethodInspection */
-        $typedCollection->assertArray([$element]);
+        $typedCollection->assertAcceptedElement($element);
     }
 
     public function testAssertAcceptedElementWillThrowExceptionOnUnacceptedElement(): void
@@ -43,20 +44,19 @@ final class TypedCollectionTraitTest extends TestCase
         $typedCollection->assertAcceptedElement($element);
     }
 
-    public function testAssertAcceptedElementWillDoNothingOnAcceptedElement(): void
+    public function testAssertArray(): void
     {
         $element = new \stdClass();
 
         $typedCollection = $this->getMockBuilder(TypedCollectionTrait::class)
-            ->onlyMethods(['isAcceptedElement'])
+            ->onlyMethods(['assertAcceptedElement'])
             ->getMockForTrait();
 
         $typedCollection->expects(self::once())
-            ->method('isAcceptedElement')
-            ->with($element)
-            ->willReturn(true);
+            ->method('assertAcceptedElement')
+            ->with($element);
 
         /** @noinspection PhpUndefinedMethodInspection */
-        $typedCollection->assertAcceptedElement($element);
+        $typedCollection->assertArray([$element]);
     }
 }

--- a/tests/TypedIndexedCollectionTest.php
+++ b/tests/TypedIndexedCollectionTest.php
@@ -10,6 +10,7 @@ final class TypedIndexedCollectionTest extends TestCase
 {
     public function testConstructWillAssertElementsAndIndices(): void
     {
+        // phpcs:disable
         $collection = new class extends TypedIndexedCollection {
             public function isAcceptedElement($element): bool
             {
@@ -21,6 +22,7 @@ final class TypedIndexedCollectionTest extends TestCase
                 return true;
             }
         };
+        // phpcs:enable
 
         self::assertInstanceOf(
             TypedIndexedCollection::class,

--- a/tests/TypedIndexedCollectionTest.php
+++ b/tests/TypedIndexedCollectionTest.php
@@ -8,10 +8,9 @@ use PHPUnit\Framework\TestCase;
 
 final class TypedIndexedCollectionTest extends TestCase
 {
-    public function testConstructWillAssertElementsAndIndices()
+    public function testConstructWillAssertElementsAndIndices(): void
     {
-        $collection = new class extends TypedIndexedCollection
-        {
+        $collection = new class extends TypedIndexedCollection {
             public function isAcceptedElement($element): bool
             {
                 return true;
@@ -23,6 +22,9 @@ final class TypedIndexedCollectionTest extends TestCase
             }
         };
 
-        self::assertInstanceOf(TypedIndexedCollection::class, new $collection([$this->createMock(\stdClass::class)]));
+        self::assertInstanceOf(
+            TypedIndexedCollection::class,
+            new $collection([$this->createMock(\stdClass::class)])
+        );
     }
 }

--- a/tests/TypedIndexedCollectionTraitTest.php
+++ b/tests/TypedIndexedCollectionTraitTest.php
@@ -14,7 +14,7 @@ final class TypedIndexedCollectionTraitTest extends TestCase
         $element = new \stdClass();
 
         $typedCollection = $this->getMockBuilder(TypedIndexedCollectionTrait::class)
-            ->setMethods(['assertAcceptedIndex', 'assertAcceptedElement'])
+            ->onlyMethods(['assertAcceptedIndex', 'assertAcceptedElement'])
             ->getMockForTrait();
 
         $typedCollection->expects(self::once())
@@ -34,7 +34,7 @@ final class TypedIndexedCollectionTraitTest extends TestCase
         $index = 'foo';
 
         $typedCollection = $this->getMockBuilder(TypedIndexedCollectionTrait::class)
-            ->setMethods(['isAcceptedIndex'])
+            ->onlyMethods(['isAcceptedIndex'])
             ->getMockForTrait();
 
         $typedCollection->expects(self::once())
@@ -53,7 +53,7 @@ final class TypedIndexedCollectionTraitTest extends TestCase
         $index = 'foo';
 
         $typedCollection = $this->getMockBuilder(TypedIndexedCollectionTrait::class)
-            ->setMethods(['isAcceptedIndex'])
+            ->onlyMethods(['isAcceptedIndex'])
             ->getMockForTrait();
 
         $typedCollection->expects(self::once())

--- a/tests/TypedIndexedCollectionTraitTest.php
+++ b/tests/TypedIndexedCollectionTraitTest.php
@@ -8,25 +8,21 @@ use PHPUnit\Framework\TestCase;
 
 final class TypedIndexedCollectionTraitTest extends TestCase
 {
-    public function testAssertArray(): void
+    public function testAssertAcceptedIndexWillDoNothingOnAcceptedElement(): void
     {
         $index = 'foo';
-        $element = new \stdClass();
 
         $typedCollection = $this->getMockBuilder(TypedIndexedCollectionTrait::class)
-            ->onlyMethods(['assertAcceptedIndex', 'assertAcceptedElement'])
+            ->onlyMethods(['isAcceptedIndex'])
             ->getMockForTrait();
 
         $typedCollection->expects(self::once())
-            ->method('assertAcceptedIndex')
-            ->with($index);
-
-        $typedCollection->expects(self::once())
-            ->method('assertAcceptedElement')
-            ->with($element);
+            ->method('isAcceptedIndex')
+            ->with($index)
+            ->willReturn(true);
 
         /** @noinspection PhpUndefinedMethodInspection */
-        $typedCollection->assertArray([$index => $element]);
+        $typedCollection->assertAcceptedIndex($index);
     }
 
     public function testAssertAcceptedIndexWillThrowExceptionOnUnacceptedElement(): void
@@ -48,20 +44,24 @@ final class TypedIndexedCollectionTraitTest extends TestCase
         $typedCollection->assertAcceptedIndex($index);
     }
 
-    public function testAssertAcceptedIndexWillDoNothingOnAcceptedElement(): void
+    public function testAssertArray(): void
     {
         $index = 'foo';
+        $element = new \stdClass();
 
         $typedCollection = $this->getMockBuilder(TypedIndexedCollectionTrait::class)
-            ->onlyMethods(['isAcceptedIndex'])
+            ->onlyMethods(['assertAcceptedIndex', 'assertAcceptedElement'])
             ->getMockForTrait();
 
         $typedCollection->expects(self::once())
-            ->method('isAcceptedIndex')
-            ->with($index)
-            ->willReturn(true);
+            ->method('assertAcceptedIndex')
+            ->with($index);
+
+        $typedCollection->expects(self::once())
+            ->method('assertAcceptedElement')
+            ->with($element);
 
         /** @noinspection PhpUndefinedMethodInspection */
-        $typedCollection->assertAcceptedIndex($index);
+        $typedCollection->assertArray([$index => $element]);
     }
 }

--- a/tests/TypedIndexedCollectionTraitTest.php
+++ b/tests/TypedIndexedCollectionTraitTest.php
@@ -8,7 +8,7 @@ use PHPUnit\Framework\TestCase;
 
 final class TypedIndexedCollectionTraitTest extends TestCase
 {
-    public function testAssertArray()
+    public function testAssertArray(): void
     {
         $index = 'foo';
         $element = new \stdClass();
@@ -29,7 +29,7 @@ final class TypedIndexedCollectionTraitTest extends TestCase
         $typedCollection->assertArray([$index => $element]);
     }
 
-    public function testAssertAcceptedIndexWillThrowExceptionOnUnacceptedElement()
+    public function testAssertAcceptedIndexWillThrowExceptionOnUnacceptedElement(): void
     {
         $index = 'foo';
 
@@ -48,7 +48,7 @@ final class TypedIndexedCollectionTraitTest extends TestCase
         $typedCollection->assertAcceptedIndex($index);
     }
 
-    public function testAssertAcceptedIndexWillDoNothingOnAcceptedElement()
+    public function testAssertAcceptedIndexWillDoNothingOnAcceptedElement(): void
     {
         $index = 'foo';
 


### PR DESCRIPTION
This PR:
- Removes support for PHP 7.0 and 7.1.
- Upgrade PHPUnit to 8.5
- Adds unit testing for PHP 7.3 and 7.4
- Removes deprecated `CollectionTrait::clear()`

Because of the BC break it requires a new major version.